### PR TITLE
Fix ros sourcing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ echo ""
 
 echo -e "\e[94mSetting up enviroment\e[0m"
 grep -qxF 'source /opt/ros/humble/setup.bash' ~/.bashrc || echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc
-source ~/.bashrc
+source /opt/ros/humble/setup.bash
 echo -e "\e[32mDone: Setting up enviroment\e[0m"
 echo ""
 
@@ -122,7 +122,7 @@ echo -e "\e[32mDone: Creating setup folder\e[0m"
 echo ""
 
 echo -e "\e[94mInstalling clearpath robot service\e[0m"
-source ~/.bashrc
+source /opt/ros/humble/setup.bash
 ros2 run clearpath_robot install
 if [ $? -eq 0 ]; then
   echo -e "\e[32mDone: Installing clearpath robot service\e[0m"
@@ -134,7 +134,6 @@ fi
 
 echo -e "\e[94mSetting up clearpath enviroment\e[0m"
 grep -qxF 'source /etc/clearpath/setup.bash' ~/.bashrc || echo 'source /etc/clearpath/setup.bash' >> ~/.bashrc
-source ~/.bashrc
 echo -e "\e[32mDone: Setting up clearpath enviroment\e[0m"
 echo ""
 


### PR DESCRIPTION
The script can't source ~/.bashrc properly, the elements need to get sourced directly. Also the clearpath setup doesn't exist yet and can't be sourced yet.

This was previously working because the micro ros section was properly sourcing ROS. 