### PR TITLE
Enable the robot service by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -179,6 +179,7 @@ else
     echo -e "\e[31mError: Failed to install clearpath robot service\e[0m"
     exit 0
 fi
+sudo systemctl enable clearpath-robot
 
 echo -e "\e[94mSetting up clearpath enviroment\e[0m"
 grep -qxF 'source /etc/clearpath/setup.bash' ~/.bashrc || echo 'source /etc/clearpath/setup.bash' >> ~/.bashrc


### PR DESCRIPTION
Currently after running install the service is not enabled and therefore does not start on its own. This is only happening with the clearpath-robot service, the other services are enabling by default. 