### PR TITLE
Add error-handling when fetching ROS 2 apt sources

### DIFF
--- a/clearpath_computer_installer.sh
+++ b/clearpath_computer_installer.sh
@@ -234,7 +234,23 @@ step_setup_osrf_packge_server() {
 
     # See https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
     export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
+
+    if [ -z "${ROS_APT_SOURCE_VERSION}" ]; then
+      # some users may encounter this error with the above:
+      #    "API rate limit exceeded for <IP>. [...]"
+      # If this happens, just use a known version.
+      log_warn "Failed to fetch latest apt-source version from GitHub. Falling back to 1.1.0"
+      export ROS_APT_SOURCE_VERSION="1.1.0"
+    fi
+
+    # URL should resolve to something like https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.noble_all.deb
+    GH_URL="https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.${UBUNTU_VERSION}_all.deb"
+    wget -L -o /tmp/ros2-apt-source.deb "${GH_URL}"
+    ret=$?
+    if [ "$ret" != "0" ] ; then
+      log_error "Failed to download OSRF apt sources from ${GH_URL}: code ${ret}. Exiting"
+      exit 0
+    fi
     sudo apt install /tmp/ros2-apt-source.deb
     sudo rm /tmp/ros2-apt-source.deb
 
@@ -349,7 +365,7 @@ step_setup_groups() {
       log_info "Adding $GROUP group";
       sudo addgroup $GROUP;
     fi
-  
+
     # 2) add the user to the group if necessary
     if id -nGz "$(whoami)" | grep -qzxF "$GROUP"; then
       log_info "User:$(whoami) is already in $GROUP group";


### PR DESCRIPTION
Some integrators have encountered rate-limiting issues when installing the OS, which results in `ROS_APT_SOURCE_VERSION` being an empty string. That leads to 404 issues, causing the subsequent `apt` invocation to fail.

1. Add a safe fallback version in case we get rate-limited (`1.1.0`, the latest at time of writing)
2. Check that downloading the file from GitHub returns `0`; otherwise abort since the file failed to download
3. Add some additional logging output to trace what's going on